### PR TITLE
Implement dockerized Pokemon API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production && npm cache clean --force
+COPY . .
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# Pokedex
+# API Pokedex
+
+API REST sencilla construida con Node.js, Express y MongoDB que se ejecuta dentro de Docker. Permite operaciones CRUD básicas protegidas con autenticación JWT.
+
+## Estructura de carpetas
+
+- `index.js` - punto de entrada de la API
+- `models/` - modelos de Mongoose
+- `routes/` - definiciones de rutas de Express
+- `middleware/` - middleware personalizado como la autenticación JWT
+- `Dockerfile` - imagen del contenedor para la API
+- `docker-compose.yml` - archivo de Compose para levantar la API y MongoDB
+
+## Ejecución
+
+1. Instala Docker y Docker Compose.
+2. Clona este repositorio y ejecuta:
+
+```bash
+docker compose up --build
+```
+
+La API estará disponible en `http://localhost:3000` y MongoDB en el puerto `27017`.
+
+## Autenticación
+
+Hay un usuario precargado mediante variables de entorno definidas en `docker-compose.yml`:
+
+- **usuario:** `admin`
+- **contraseña:** `password`
+
+Obtén un token enviando una solicitud POST a `/login` con `username` y `password`. Usa el token devuelto en la cabecera `Authorization` como `Bearer <token>` para los endpoints protegidos.
+
+## Endpoints
+
+Todas las rutas bajo `/pokemon` requieren autenticación.
+
+| Método | Endpoint       | Descripción        |
+| ------ | -------------- | ------------------ |
+| POST   | `/pokemon`     | Crea un pokemon    |
+| GET    | `/pokemon`     | Lista los pokemons |
+| GET    | `/pokemon/:id` | Obtiene por id     |
+| PUT    | `/pokemon/:id` | Actualiza          |
+| DELETE | `/pokemon/:id` | Elimina            |
+
+## Ejemplo de uso
+
+```bash
+curl -X POST http://localhost:3000/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"password"}'
+```
+
+Utiliza el token devuelto para las peticiones autorizadas:
+
+```bash
+curl http://localhost:3000/pokemon \
+  -H "Authorization: Bearer <token>"
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - MONGO_URL=mongodb://mongo:27017/pokedex
+      - JWT_SECRET=supersecret
+      - API_USER=admin
+      - API_PASS=password
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:7
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+volumes:
+  mongo-data:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const pokemonRoutes = require('./routes/pokemon');
+const authMiddleware = require('./middleware/auth');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const MONGO_URL = process.env.MONGO_URL || 'mongodb://mongo:27017/pokedex';
+const SECRET = process.env.JWT_SECRET || 'supersecret';
+
+const USERNAME = process.env.API_USER || 'admin';
+const PASSWORD_HASH = bcrypt.hashSync(process.env.API_PASS || 'password', 8);
+
+mongoose.connect(MONGO_URL)
+  .then(() => console.log('Connected to MongoDB'))
+  .catch(err => console.error('MongoDB connection error:', err));
+
+app.use(express.json());
+
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (username !== USERNAME) return res.status(401).json({ message: 'Invalid cred' });
+  const valid = bcrypt.compareSync(password, PASSWORD_HASH);
+  if (!valid) return res.status(401).json({ message: 'Invalid cred' });
+  const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.use('/pokemon', authMiddleware, pokemonRoutes);
+
+app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,15 @@
+const jwt = require('jsonwebtoken');
+
+const SECRET = process.env.JWT_SECRET || 'supersecret';
+
+module.exports = function(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'Token required' });
+
+  jwt.verify(token, SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token' });
+    req.user = user;
+    next();
+  });
+};

--- a/models/pokemon.js
+++ b/models/pokemon.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const PokemonSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  type: { type: String, required: true }
+});
+
+module.exports = mongoose.model('Pokemon', PokemonSchema);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pokedex",
+  "version": "1.0.0",
+  "description": "Simple Pokemon API with authentication",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.4",
+    "mongoose": "^8.3.2",
+    "jsonwebtoken": "^9.0.1",
+    "bcryptjs": "^2.4.3"
+  }
+}

--- a/routes/pokemon.js
+++ b/routes/pokemon.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const Pokemon = require('../models/pokemon');
+const router = express.Router();
+
+// Create
+router.post('/', async (req, res) => {
+  try {
+    const pokemon = await Pokemon.create(req.body);
+    res.status(201).json(pokemon);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Read all
+router.get('/', async (req, res) => {
+  const pokemons = await Pokemon.find();
+  res.json(pokemons);
+});
+
+// Read one
+router.get('/:id', async (req, res) => {
+  try {
+    const pokemon = await Pokemon.findById(req.params.id);
+    if (!pokemon) return res.status(404).json({ message: 'Not found' });
+    res.json(pokemon);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Update
+router.put('/:id', async (req, res) => {
+  try {
+    const pokemon = await Pokemon.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!pokemon) return res.status(404).json({ message: 'Not found' });
+    res.json(pokemon);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Delete
+router.delete('/:id', async (req, res) => {
+  try {
+    const pokemon = await Pokemon.findByIdAndDelete(req.params.id);
+    if (!pokemon) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- initialize Node project with Express and MongoDB
- add pokemon model, routes, and JWT middleware
- configure Dockerfile and docker-compose
- provide README with usage instructions
- traducir README al español

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685f15b30de48326af5b46ad37ca8aa9